### PR TITLE
Fix "gettext" and "gnutls" dependencies

### DIFF
--- a/make/gettext.mk
+++ b/make/gettext.mk
@@ -29,10 +29,10 @@ GETTEXT_MAINTAINER=NSLU2 Linux <nslu2-linux@yahoogroups.com>
 GETTEXT_DESCRIPTION=Set of tools for producing multi-lingual messages
 LIBINTL_DESCRIPTION=gettext libintl
 ifneq (libiconv, $(filter libiconv, $(PACKAGES)))
-GETTEXT_DEPENDS=libintl, libunistring, libacl, ncurses
+GETTEXT_DEPENDS=libintl, libunistring, ncurses
 LIBINTL_DEPENDS=
 else
-GETTEXT_DEPENDS=libintl, libunistring, libacl, ncurses, libiconv
+GETTEXT_DEPENDS=libintl, libunistring, ncurses, libiconv
 LIBINTL_DEPENDS=libiconv
 endif
 GETTEXT_SUGGESTS=
@@ -41,7 +41,7 @@ GETTEXT_CONFLICTS=
 #
 # GETTEXT_IPK_VERSION should be incremented when the ipk changes.
 #
-GETTEXT_IPK_VERSION=4
+GETTEXT_IPK_VERSION=5
 
 #
 # GETTEXT_CONFFILES should be a list of user-editable files
@@ -152,7 +152,7 @@ $(GETTEXT_BUILD_DIR)/.configured: $(DL_DIR)/$(GETTEXT_SOURCE) $(GETTEXT_PATCHES)
 ifeq (libiconv, $(filter libiconv, $(PACKAGES)))
 	$(MAKE) libiconv-stage
 endif
-	$(MAKE) libunistring-stage libacl-stage ncurses-stage
+	$(MAKE) libunistring-stage ncurses-stage
 	rm -rf $(BUILD_DIR)/$(GETTEXT_DIR) $(@D)
 	$(GETTEXT_UNZIP) $(DL_DIR)/$(GETTEXT_SOURCE) | tar -C $(BUILD_DIR) -xvf -
 	cat $(GETTEXT_PATCHES) | $(PATCH) -d $(BUILD_DIR)/$(GETTEXT_DIR) -p1
@@ -170,6 +170,7 @@ endif
 		--target=$(GNU_TARGET_NAME) \
 		--prefix=$(TARGET_PREFIX) \
 		--$(GETTEXT_NLS)-nls \
+		--with-included-libacl \
 		--with-included-libcroco \
 		--with-included-glib \
 		--disable-static \

--- a/make/gnutls.mk
+++ b/make/gnutls.mk
@@ -35,14 +35,14 @@ GNUTLS_MAINTAINER=NSLU2 Linux <nslu2-linux@yahoogroups.com>
 GNUTLS_DESCRIPTION=GNU Transport Layer Security Library.
 GNUTLS_SECTION=libs
 GNUTLS_PRIORITY=optional
-GNUTLS_DEPENDS=libtasn1, libgcrypt, libgpg-error, zlib, libnettle
+GNUTLS_DEPENDS=libtasn1, libgcrypt, libgpg-error, zlib, libnettle, libunistring
 GNUTLS_SUGGESTS=
 GNUTLS_CONFLICTS=
 
 #
 # GNUTLS_IPK_VERSION should be incremented when the ipk changes.
 #
-GNUTLS_IPK_VERSION=1
+GNUTLS_IPK_VERSION=2
 
 #
 # GNUTLS_CONFFILES should be a list of user-editable files
@@ -112,7 +112,7 @@ gnutls-source: $(DL_DIR)/$(GNUTLS_SOURCE) $(GNUTLS_PATCHES)
 # first, then do that first (e.g. "$(MAKE) <bar>-stage <baz>-stage").
 #
 $(GNUTLS_BUILD_DIR)/.configured: $(DL_DIR)/$(GNUTLS_SOURCE) $(GNUTLS_PATCHES) make/gnutls.mk
-	$(MAKE) libgcrypt-stage libtasn1-stage libnettle-stage
+	$(MAKE) libgcrypt-stage libtasn1-stage libnettle-stage libunistring-stage
 	rm -rf $(BUILD_DIR)/$(GNUTLS_DIR) $(GNUTLS_BUILD_DIR)
 	$(GNUTLS_UNZIP) $(DL_DIR)/$(GNUTLS_SOURCE) | tar -C $(BUILD_DIR) -xvf -
 	if test -n "$(GNUTLS_PATCHES)"; \


### PR DESCRIPTION
The most recent 'gettext' dependency change (adding 'libacl') unfortunately introduces another circular dependency ( 'gettext' => 'libacl' => 'attr' => 'gettext' ). I repaired it in a similar manner to your recent repair.

'gnutls' was missing 'libunistring'.

This PR fixes both.